### PR TITLE
Remove creating/deleting a new style

### DIFF
--- a/fancytabbar.cpp
+++ b/fancytabbar.cpp
@@ -31,7 +31,6 @@
 #include <stylehelper.h>
 
 #include <QMouseEvent>
-#include <QWindowsStyle>
 #include <QPainter>
 #include <QColor>
 #include <QStackedLayout>
@@ -59,7 +58,6 @@ FancyTabBar::FancyTabBar(const TabBarPosition position, QWidget *parent)
         setSizePolicy(QSizePolicy::Preferred, QSizePolicy::Expanding);
     }
 
-    setStyle(new QWindowsStyle);
     setAttribute(Qt::WA_Hover, true);
     setFocusPolicy(Qt::NoFocus);
     setMouseTracking(true); // Needed for hover events
@@ -71,7 +69,6 @@ FancyTabBar::FancyTabBar(const TabBarPosition position, QWidget *parent)
 
 FancyTabBar::~FancyTabBar()
 {
-    delete style();
 }
 
 QSize FancyTabBar::tabSizeHint(bool minimum) const


### PR DESCRIPTION
In Qt5 class QWindowsStyle is in private API, so in order to make FancyTabBar work on Qt5, I propose to remove creating of a new style in ctor, and it deletion in dtor.

P.S. To be honest I don't understand why it is need to create a new style fot this wgt.
